### PR TITLE
fix for different column order in new MacOSX

### DIFF
--- a/ls++
+++ b/ls++
@@ -175,6 +175,12 @@ sub ls {
     }
     elsif( ($^O eq 'darwin') or ($^O =~ /.+bsd$/) ) {
         ($perm, $hlink, $user, $group, $size, $day, $month, $time, $year, $file) = split(/\s+/, $line, 10);
+
+        # apparntly new MacOSX changed the order of columnns
+        if (!($day =~ /\d+/)) {
+          ($day, $month) = ($month, $day);
+        }
+
         chop($file);
         if( (!$day) ) {
           printf("%s", $line);


### PR DESCRIPTION
on my MacOSX (Ventura 13.5.2) the ls command reports fields in different order breaking ls++